### PR TITLE
Changes to work with python 3.9

### DIFF
--- a/osgb/convert.py
+++ b/osgb/convert.py
@@ -47,14 +47,14 @@ if sys.version_info > (3, 0):
 else:
     OSTN_EE_SHIFTS = array.array(b'H')
     try:
-        OSTN_EE_SHIFTS.fromstring(pkgutil.get_data("osgb", "ostn_east_shift_82140"))
+        OSTN_EE_SHIFTS.frombytes(pkgutil.get_data("osgb", "ostn_east_shift_82140"))
     except TypeError:
         print("Failed to load OSTN eastings from file", file=sys.stderr)
         raise
 
     OSTN_NN_SHIFTS = array.array(b'H')
     try:
-        OSTN_NN_SHIFTS.fromstring(pkgutil.get_data("osgb", "ostn_north_shift_-84180"))
+        OSTN_NN_SHIFTS.frombytes(pkgutil.get_data("osgb", "ostn_north_shift_-84180"))
     except TypeError:
         print("Failed to load OSTN northings from file", file=sys.stderr)
         raise

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     url='http://thurston.eml.cc',
     packages=['osgb'],
     package_data={'osgb': ['ostn_east_shift_82140', 'ostn_north_shift_-84180', 'gb_coastline.shapes']},
-    scripts=['scripts/bngl', 'scripts/whatmaps.py', 'scripts/plot_maps.py'],
+    scripts=['scripts/bngl.py', 'scripts/whatmaps.py', 'scripts/plot_maps.py'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
fromstring() and tostring() methods [removed from python3.9](https://docs.python.org/3/whatsnew/3.9.html). Replaced with frombytes() and tobytes()